### PR TITLE
share on wp,fb - dashboard, note-view, latest

### DIFF
--- a/public/js/controller.js
+++ b/public/js/controller.js
@@ -40,7 +40,7 @@ function finish() {
 // Share Note Modal
 
 const linkElement = document.querySelector('._link_');
-function setupShareModal() {
+function setupShareModal(noteID) {
     const shareNoteModal = document.querySelector('.share-note-overlay');
     const closeNoteModalBtn = document.querySelector('.close-share-note-modal');
 
@@ -51,7 +51,7 @@ function setupShareModal() {
 
     // Open the modal and populate the link (immediate execution)
     shareNoteModal.style.display = 'flex'; 
-    linkElement.innerHTML = `${window.location.origin}${window.location.pathname}`;
+    linkElement.innerHTML = `${window.location.origin}/view/${noteID}`;
     requestAnimationFrame(() => { 
         shareNoteModal.classList.add('visible');
     });
@@ -65,8 +65,6 @@ function setupShareModal() {
 }
 
 function copyLink() {
-    const linkElement = document.querySelector('._link_');
-
     navigator.clipboard.writeText(linkElement.textContent)
         .then(() => {
             alert('Link copied to clipboard!');
@@ -77,17 +75,15 @@ function copyLink() {
 }
 
 function share(platform) {
-    function sharePage(baseContent) {
-        window.open(baseContent, '_blank')
-    }
+    const linkElement = document.querySelector('._link_').innerHTML;
 
     switch(platform) {
         case "facebook":
-            sharePage(`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(linkElement.innerHTML)}`)
+            window.open(`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(linkElement + '/shared')}`, '_blank')
             break
         case "whatsapp":
-            let message = `Check out this note: ${document.querySelector('h2.section-title').innerHTML} - ${linkElement.innerHTML}`
-            sharePage(`https://api.whatsapp.com/send?text=${encodeURIComponent(message)}`)
+            let message = `Check out this note on NoteRoom: ${linkElement}`
+            window.open(`https://api.whatsapp.com/send?text=${encodeURIComponent(message)}`, '_blank')
             break
     }
 }

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -45,7 +45,7 @@ function addNote(noteData) {
 						<svg onclick="window.location.href='/view/${noteData.noteID}/#feedbacks';" class="comment-icon" width="40" height="40" viewBox="0 0 36 37" fill="none" xmlns="http://www.w3.org/2000/svg">
 							<path d="M34.4051 23.9151C34.4051 24.8838 34.0257 25.8128 33.3505 26.4978C32.6753 27.1828 31.7595 27.5676 30.8045 27.5676H9.20113L2 34.8726V5.65252C2 4.68381 2.37934 3.75478 3.05458 3.0698C3.72982 2.38482 4.64564 2 5.60057 2H30.8045C31.7595 2 32.6753 2.38482 33.3505 3.0698C34.0257 3.75478 34.4051 4.68381 34.4051 5.65252V23.9151Z" stroke="#1E1E1E" stroke-width="2.40038" stroke-linecap="round" stroke-linejoin="round"/>
 						</svg>
-						<svg class="share-icon" width="40" height="40" viewBox="0 0 46 46" fill="none" xmlns="http://www.w3.org/2000/svg" onclick="setupShareModal()">
+						<svg class="share-icon" width="40" height="40" viewBox="0 0 46 46" fill="none" xmlns="http://www.w3.org/2000/svg" onclick="setupShareModal(${noteData.noteID})">
 							<path d="M30.6079 32.5223L27.8819 29.8441L36.6816 21.0444L27.8819 12.2446L30.6079 9.56641L42.0858 21.0444L30.6079 32.5223ZM3.82599 36.3483V28.6963C3.82599 26.05 4.7506 23.8023 6.59983 21.953C8.48094 20.0719 10.7446 19.1314 13.391 19.1314H25.2037L18.3169 12.2446L21.0429 9.56641L32.5209 21.0444L21.0429 32.5223L18.3169 29.8441L25.2037 22.9574H13.391C11.7968 22.9574 10.4418 23.5153 9.32584 24.6312C8.20993 25.7471 7.65197 27.1022 7.65197 28.6963V36.3483H3.82599Z" fill="#1D1B20"/>
 						</svg>
 					</div>            

--- a/server/routers/note-view.js
+++ b/server/routers/note-view.js
@@ -115,6 +115,18 @@ function noteViewRouter(io) {
         }
     })
 
+    router.get('/:noteID/shared', async (req, res, next) => {
+        let headers = req.headers['user-agent']
+        let noteDocID = req.params.noteID
+        let note = (await getNote(noteDocID)).note
+
+        if(headers.includes('facebook')) {
+            res.render('shared', { note: note, req: req })
+        } else {
+            res.redirect(`/view/${noteDocID}`)
+        }
+    })
+
     return router
 }
 

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -23,8 +23,8 @@
   </head>
 
   <body>
-    <%- include('side-panel', { block: 'left-panel' }) %> <%-
-    include('side-panel', { block: 'search-bar' }) %>
+    <%- include('side-panel', { block: 'left-panel' }) %> 
+    <%- include('side-panel', { block: 'search-bar' }) %>
 
     <div class="middle-section">
       <!--* The main feed back container where all the notes will be shown dynamically -->
@@ -120,7 +120,7 @@
                 viewBox="0 0 46 46"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
-                onclick="setupShareModal()"
+                onclick="setupShareModal('<%= note._id %>')"
               >
                 <path
                   d="M30.6079 32.5223L27.8819 29.8441L36.6816 21.0444L27.8819 12.2446L30.6079 9.56641L42.0858 21.0444L30.6079 32.5223ZM3.82599 36.3483V28.6963C3.82599 26.05 4.7506 23.8023 6.59983 21.953C8.48094 20.0719 10.7446 19.1314 13.391 19.1314H25.2037L18.3169 12.2446L21.0429 9.56641L32.5209 21.0444L21.0429 32.5223L18.3169 29.8441L25.2037 22.9574H13.391C11.7968 22.9574 10.4418 23.5153 9.32584 24.6312C8.20993 25.7471 7.65197 27.1022 7.65197 28.6963V36.3483H3.82599Z"

--- a/views/note-view.ejs
+++ b/views/note-view.ejs
@@ -3,10 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="og:title" content="<%= note.title %>">
-    <meta property="og:description" content="<%= note.description.slice(0, 30) %>">
-    <meta property="og:image" content="<%= note.content[0] %>">
-    <meta property="og:type" content="website">
     <link rel="stylesheet" href="/css/main-pages.css" />
     <link rel="stylesheet" href="/css/note-view.css" />
     <link rel="stylesheet" href="/css/loaders.css" />
@@ -111,7 +107,7 @@
             viewBox="0 0 46 46"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
-            onclick="setupShareModal()"
+            onclick="setupShareModal('<%= note._id %>')"
           >
             <path
               d="M30.6079 32.5223L27.8819 29.8441L36.6816 21.0444L27.8819 12.2446L30.6079 9.56641L42.0858 21.0444L30.6079 32.5223ZM3.82599 36.3483V28.6963C3.82599 26.05 4.7506 23.8023 6.59983 21.953C8.48094 20.0719 10.7446 19.1314 13.391 19.1314H25.2037L18.3169 12.2446L21.0429 9.56641L32.5209 21.0444L21.0429 32.5223L18.3169 29.8441L25.2037 22.9574H13.391C11.7968 22.9574 10.4418 23.5153 9.32584 24.6312C8.20993 25.7471 7.65197 27.1022 7.65197 28.6963V36.3483H3.82599Z"

--- a/views/shared.ejs
+++ b/views/shared.ejs
@@ -1,0 +1,17 @@
+<html>
+    <head>
+        <meta property="og:title" content="<%= note.title %>">
+        <meta property="og:description" content="<%= note.description.slice(0, 30) %>">
+        <meta property="og:image" content="<%= note.content[0] %>">
+        <meta property="og:type" content="website">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+        integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    </head>
+    <body>
+        <span class="note-id" style="display: none;"><%= note._id %></span>
+        <div class="container">
+            <p>Sorry for the inconvenience, click the button below to see the original note</p>
+            <button class="btn btn-success" type="button" onclick="window.location.href = `${window.location.origin}/view/${document.querySelector('.note-id').innerHTML}`">View Note</button>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Now notes can be shared from dashboard and note-view. They share the exact same functionality (no DRY). Also the setupsharemodel now takes the note-id on which all the copy and share things will happen and perform those actions. 

Notes can be shared on facebook and whatsapp now