### PR TITLE
Test/react test

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import ScrollPositionProvider from "./context/ScrollPosition";
 import Settings from "./pages/settings/Settings";	
 import UserProfile from "./pages/user-profile/UserProfile";
 import AppDataProvider from "./context/AppDataContext";
+import UploadNote from "./pages/upload-note/UploadNote";
 // import SignUp from "./pages/sign-up/SignUp";
 // import Login from "./pages/login/Login";
 
@@ -43,6 +44,9 @@ function App() {
 				<Route path="/user/:username" element={<UserProfile />} />
 				<Route path="/search-profile" element={<SearchProfile />} />
 				<Route path="/settings" element={<Settings />} />
+				<Route path="/upload-note" element={<UploadNote />} />
+				{/* <Route path="/sign-up" element={<SignUp />} />
+				<Route path="/login" element={<Login />} /> */}
 			</Routes>
 
 			<RightPanel notiModalState={[showNotiModal, setShowNotiModal]} rightPanelState={showRightPanel}/>		

--- a/frontend/src/pages/upload-note/UploadNote.tsx
+++ b/frontend/src/pages/upload-note/UploadNote.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import Quill, { QuillOptions } from "quill";
 import "quill/dist/quill.snow.css";
-import io, { Socket } from "socket.io-client";
 import Swal from "sweetalert2";
 import ThumbnailPopup from "./ThumbnailPopup";
 import "../../public/css/upload-note.css";
@@ -20,7 +19,6 @@ const UploadNote: React.FC = () => {
   const editorRef = useRef<HTMLDivElement>(null);
   const quillRef = useRef<Quill | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const socketRef = useRef<Socket>(io(window.location.origin));
 
   useEffect(() => {
     if (editorRef.current && !quillRef.current) {
@@ -32,14 +30,46 @@ const UploadNote: React.FC = () => {
           toolbar: toolbarOptions,
         },
       } as QuillOptions);
-      editorRef.current.style.height = "250px"; // Slightly taller for a pro look
+      editorRef.current.style.height = "250px";
     }
+
+    return () => {
+      if (quillRef.current) {
+        quillRef.current = null;
+      }
+    };
   }, []);
 
+  // file uploads with validation for type and size
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files ? Array.from(e.target.files) : [];
-    setStackFiles((prev) => [...prev, ...files]);
-    showUploadEffect();
+    const maxSize = 10 * 1024 * 1024; 
+    const validTypes = ["image/png", "image/jpeg"];
+
+    const validFiles = files.filter((file) => {
+      if (!validTypes.includes(file.type)) {
+        Swal.fire({
+          icon: "error",
+          title: "Invalid File Type",
+          text: `${file.name} is not a supported format (PNG or JPG only).`,
+        });
+        return false;
+      }
+
+      if (file.size > maxSize) {
+        Swal.fire({
+          icon: "error",
+          title: "File Too Large",
+          text: `${file.name} exceeds the 10MB limit.`,
+        });
+        return false;
+      }
+
+      return true;
+    });
+
+    setStackFiles((prev) => [...prev, ...validFiles]);
+    if (validFiles.length > 0) showUploadEffect();
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
@@ -66,7 +96,7 @@ const UploadNote: React.FC = () => {
     }
   };
 
-  const handlePublish = () => {
+  const handlePublish = async () => {
     if (stackFiles.length < 2) {
       Swal.fire({
         icon: "warning",
@@ -82,13 +112,10 @@ const UploadNote: React.FC = () => {
     const noteTitle = (
       document.querySelector(".note-title") as HTMLInputElement
     )?.value;
+    const descriptionText = quillRef.current?.getText().trim() || "";
     const noteDescription = quillRef.current?.root.innerHTML || "";
 
-    if (
-      !noteSubject ||
-      !noteTitle ||
-      !quillRef.current?.root?.textContent?.trim()
-    ) {
+    if (!noteSubject || !noteTitle || !descriptionText) {
       Swal.fire({
         icon: "error",
         title: "Incomplete Form",
@@ -97,27 +124,67 @@ const UploadNote: React.FC = () => {
       return;
     }
 
-    // your the data array
+    setIsLoading(true);
+
+    // your note data object for logging
     const noteData = {
       title: noteTitle,
       subject: noteSubject,
       description: noteDescription,
-      images: stackFiles,
+      images: stackFiles, 
     };
 
     console.log("Published Note Data:", noteData);
 
-    Swal.fire({
-      icon: "success",
-      title: "Data Collected",
-      text: "Your note data has been collected! Check the console for details.",
-    });
-    setStackFiles([]);
-    setIsPopupOpen(false);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-    (document.querySelector(".note-subject") as HTMLSelectElement).value = "";
-    (document.querySelector(".note-title") as HTMLInputElement).value = "";
-    if (quillRef.current) quillRef.current.root.innerHTML = "";
+    const formData = new FormData();
+    stackFiles.forEach((file, index) =>
+      formData.append(`image-${index}`, file)
+    );
+    formData.append("noteSubject", noteSubject);
+    formData.append("noteTitle", noteTitle);
+    formData.append("noteDescription", noteDescription);
+
+    try {
+      Swal.fire({
+        icon: "info",
+        title: "Processing Upload",
+        text: "Your note is being uploaded. Please wait...",
+        showConfirmButton: false,
+      });
+      const response = await fetch("/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const responseData = await response.json();
+      if (response.ok) {
+        setStackFiles([]);
+        setIsPopupOpen(false);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+        (document.querySelector(".note-subject") as HTMLSelectElement).value = "";
+        (document.querySelector(".note-title") as HTMLInputElement).value = "";
+        if (quillRef.current) quillRef.current.root.innerHTML = "";
+
+        Swal.fire({
+          icon: "success",
+          title: "Upload Complete",
+          text: "Your note has been published!",
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "Upload Failed",
+          text: responseData.message || "Something went wrong.",
+        });
+      }
+    } catch (error) {
+      Swal.fire({
+        icon: "error",
+        title: "Connection Error",
+        text: "Please check your internet connection and try again.",
+      });
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -167,6 +234,7 @@ const UploadNote: React.FC = () => {
             multiple
             ref={fileInputRef}
             onChange={handleFileChange}
+            accept="image/png, image/jpeg"
           />
           <label htmlFor="fileInput" className="browse-files-btn">
             Select Files
@@ -214,7 +282,7 @@ const UploadNote: React.FC = () => {
                 fill="#1D8102"
               />
               <path
-                d="M20.0564 8.62512L11.744 16.9376L7.94357 13.1371C7.49539 12.689 6.76887 12.689 6.32069 13.1371C5.8726 13.5853 5.8726 14.3118 6.32069 14.76L10.9326 19.3719C11.1567 19.5959 11.4503 19.708 11.744 19.708C12.0377 19.708 12.3314 19.5959 12.5555 19.3719L21.6793 10.2481C22.1274 9.79992 22.1274 9.07339 21.6793 8.62521C21.2311 8.17703 20.5045 8.17703 20.0564 8.62512Z"
+                d="M20.0564 8.62512L11.744 16.9376L7.94357 13.1371C7.49539 12.689 6.76887 12.689 6.32069 13.1371C5.8726 13.5853 5.8726 14.3118 6.32069 14.76L10.9326 19.3719C11.1567 19.5959 11.4503 19.708 11.744 19.708C12.0377 19.708 12.3314 19.708 12.5555 19.3719L21.6793 10.2481C22.1274 9.79992 22.1274 9.07339 21.6793 8.62521C21.2311 8.17703 20.5045 8.17703 20.0564 8.62512Z"
                 fill="#1D8102"
               />
             </g>

--- a/frontend/src/pages/upload-note/UploadNote.tsx
+++ b/frontend/src/pages/upload-note/UploadNote.tsx
@@ -4,7 +4,7 @@ import "quill/dist/quill.snow.css";
 import io, { Socket } from "socket.io-client";
 import Swal from "sweetalert2";
 import ThumbnailPopup from "./ThumbnailPopup";
-import "../styles.css";
+import "../../public/css/upload-note.css";
 
 const toolbarOptions = [
   ["bold", "italic", "underline"],

--- a/frontend/src/pages/upload-note/UploadNote.tsx
+++ b/frontend/src/pages/upload-note/UploadNote.tsx
@@ -45,11 +45,17 @@ const UploadNote: React.FC = () => {
 
   const updateStackStatus = (): string => {
     const count = stackFiles.length;
-    return count === 0 ? "No Images" : count === 1 ? "1 Image" : `${count} Images`;
+    return count === 0
+      ? "No Images"
+      : count === 1
+      ? "1 Image"
+      : `${count} Images`;
   };
 
   const showUploadEffect = () => {
-    const uploadMsg = document.querySelector(".success-upload-msg") as HTMLElement;
+    const uploadMsg = document.querySelector(
+      ".success-upload-msg"
+    ) as HTMLElement;
     if (uploadMsg) {
       uploadMsg.style.display = "flex";
       requestAnimationFrame(() => uploadMsg.classList.add("s-u-effect"));
@@ -60,7 +66,7 @@ const UploadNote: React.FC = () => {
     }
   };
 
-  const handlePublish = async () => {
+  const handlePublish = () => {
     if (stackFiles.length < 2) {
       Swal.fire({
         icon: "warning",
@@ -70,11 +76,19 @@ const UploadNote: React.FC = () => {
       return;
     }
 
-    const noteSubject = (document.querySelector(".note-subject") as HTMLSelectElement)?.value;
-    const noteTitle = (document.querySelector(".note-title") as HTMLInputElement)?.value;
+    const noteSubject = (
+      document.querySelector(".note-subject") as HTMLSelectElement
+    )?.value;
+    const noteTitle = (
+      document.querySelector(".note-title") as HTMLInputElement
+    )?.value;
     const noteDescription = quillRef.current?.root.innerHTML || "";
 
-    if (!noteSubject || !noteTitle || !quillRef.current?.root?.textContent?.trim()) {
+    if (
+      !noteSubject ||
+      !noteTitle ||
+      !quillRef.current?.root?.textContent?.trim()
+    ) {
       Swal.fire({
         icon: "error",
         title: "Incomplete Form",
@@ -83,50 +97,47 @@ const UploadNote: React.FC = () => {
       return;
     }
 
-    setIsLoading(true);
-    const formData = new FormData();
-    stackFiles.forEach((file, index) => formData.append(`image-${index}`, file));
-    formData.append("noteSubject", noteSubject);
-    formData.append("noteTitle", noteTitle);
-    formData.append("noteDescription", noteDescription);
+    // your the data array
+    const noteData = {
+      title: noteTitle,
+      subject: noteSubject,
+      description: noteDescription,
+      images: stackFiles,
+    };
 
-    try {
-      Swal.fire({
-        icon: "info",
-        title: "Processing Upload",
-        text: "Your note is being uploaded. Please wait...",
-        showConfirmButton: false,
-      });
-      const response = await new Promise<{ ok: boolean; message?: string }>((resolve) =>
-        setTimeout(() => resolve({ ok: true }), 2000)
-      );
-      if (response.ok) {
-        setStackFiles([]);
-        Swal.fire({ icon: "success", title: "Upload Complete", text: "Your note has been published!" });
-      } else {
-        Swal.fire({ icon: "error", title: "Upload Failed", text: response.message });
-      }
-    } catch (error) {
-      Swal.fire({
-        icon: "error",
-        title: "Connection Error",
-        text: "Please check your internet connection and try again.",
-      });
-    } finally {
-      setIsLoading(false);
-    }
+    console.log("Published Note Data:", noteData);
+
+    Swal.fire({
+      icon: "success",
+      title: "Data Collected",
+      text: "Your note data has been collected! Check the console for details.",
+    });
+    setStackFiles([]);
+    setIsPopupOpen(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    (document.querySelector(".note-subject") as HTMLSelectElement).value = "";
+    (document.querySelector(".note-title") as HTMLInputElement).value = "";
+    if (quillRef.current) quillRef.current.root.innerHTML = "";
   };
 
   return (
     <div className="middle-section">
       <header className="section-header">
         <h2>Upload New Note</h2>
-        <p className="header-subtitle">Upload images and add details to share your study notes.</p>
+        <p className="header-subtitle">
+          Upload images and add details to share your study notes.
+        </p>
       </header>
 
       <div className="upload-container">
         <div className="upload-icon">
-          <svg width="60" height="60" viewBox="0 0 73 73" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            width="60"
+            height="60"
+            viewBox="0 0 73 73"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <g clipPath="url(#clip0_606_961)">
               <path
                 d="M48.3085 48.3057L36.2314 36.2286M36.2314 36.2286L24.1542 48.3057M36.2314 36.2286V63.4021M61.5631 55.5218C64.5079 53.9164 66.8343 51.376 68.175 48.3016C69.5156 45.2272 69.7943 41.7938 68.967 38.5435C68.1397 35.2931 66.2535 32.4108 63.6062 30.3514C60.9588 28.2921 57.7011 27.173 54.347 27.1708H50.5427C49.6289 23.6359 47.9255 20.3542 45.5608 17.5724C43.196 14.7907 40.2314 12.5811 36.8899 11.11C33.5483 9.6389 29.9167 8.94445 26.2681 9.07888C22.6195 9.21331 19.0488 10.1731 15.8246 11.8862C12.6003 13.5992 9.80635 16.0209 7.65273 18.9691C5.49911 21.9174 4.04188 25.3155 3.39059 28.908C2.7393 32.5006 2.9109 36.194 3.89249 39.7106C4.87409 43.2273 6.64013 46.4756 9.05784 49.2115"
@@ -144,7 +155,9 @@ const UploadNote: React.FC = () => {
           </svg>
         </div>
         <p className="upload-msg">Upload Images</p>
-        <p className="suggested-formats-msg">Supported: PNG, JPG (Max 10MB each)</p>
+        <p className="suggested-formats-msg">
+          Supported: PNG, JPG (Max 10MB each)
+        </p>
         <div className="browse-file-container">
           <input
             type="file"
@@ -188,7 +201,13 @@ const UploadNote: React.FC = () => {
           <span className="stack-prompt">View Stack</span>
         </div>
         <div className="success-upload-msg">
-          <svg width="20" height="20" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 28 28"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <g clipPath="url(#clip0_1844_2149)">
               <path
                 d="M14.0001 0C6.28041 0 0 6.28031 0 13.9999C0 21.7195 6.28041 27.9998 14.0001 27.9998C21.7197 27.9998 28 21.7195 28 13.9999C28 6.28031 21.7197 0 14.0001 0ZM14.0001 25.7047C7.5459 25.7047 2.29507 20.4541 2.29507 13.9999C2.29507 7.54581 7.5459 2.29507 14.0001 2.29507C20.4542 2.29507 25.7049 7.54581 25.7049 13.9999C25.7049 20.4541 20.4542 25.7047 14.0001 25.7047Z"
@@ -212,7 +231,13 @@ const UploadNote: React.FC = () => {
       <div className="text-form">
         <div className="form-group">
           <label htmlFor="noteSubject">Subject</label>
-          <select name="noteSubject" id="noteSubject" className="note-subject" defaultValue="" required>
+          <select
+            name="noteSubject"
+            id="noteSubject"
+            className="note-subject"
+            defaultValue=""
+            required
+          >
             <option value="" disabled>
               Select a Subject
             </option>
@@ -264,12 +289,19 @@ const UploadNote: React.FC = () => {
             <div ref={editorRef} />
           </div>
         </div>
-        <button className="publish-note-btn" onClick={handlePublish} disabled={isLoading}>
+        <button
+          className="publish-note-btn"
+          onClick={handlePublish}
+          disabled={isLoading}
+        >
           {isLoading ? "Publishing..." : "Publish Note"}
         </button>
       </div>
 
-      <div className="overlay" style={{ display: isPopupOpen ? "block" : "none" }} />
+      <div
+        className="overlay"
+        style={{ display: isPopupOpen ? "block" : "none" }}
+      />
       <ThumbnailPopup
         isOpen={isPopupOpen}
         stackFiles={stackFiles}

--- a/frontend/src/public/css/upload-note.css
+++ b/frontend/src/public/css/upload-note.css
@@ -15,13 +15,14 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--light-gray);
   padding: clamp(10px, 2vw, 20px);
   min-height: 100vh;
 }
 
 .middle-section {
   width: 100%;
+  height: auto;
+  margin-top: 90px;
   max-width: 1000px;
   background: #fff;
   border-radius: 12px;
@@ -33,22 +34,44 @@ body {
 }
 
 .section-header {
+  margin-top: -10px;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  border: none;
+  border-bottom: none !important;
+  margin-bottom: -10px;
 }
 
 .section-header h2 {
   font-size: clamp(1.5rem, 4vw, 1.75rem);
   font-weight: 600;
   color: var(--squid-ink);
-  margin-bottom: 8px;
+  margin-bottom: 12px;
+  width: 100%;
+  display: block;
+  border-bottom: none;
 }
 
-.header-subtitle {
+.section-header .header-subtitle {
   font-size: clamp(0.9rem, 2.5vw, 1rem);
   color: #666;
+  width: 100%;
+  max-width: 90%;
+  display: block;
+  margin: 0;
+  padding: 0;
 }
 
+.section-header::before,
+.section-header::after {
+  display: none !important;
+  content: none;
+}
 .upload-container {
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -111,7 +134,6 @@ body {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  align-items: center;
   gap: 10px;
 }
 
@@ -141,6 +163,7 @@ body {
 }
 
 .stack-prompt {
+  width: 100%;
   font-size: clamp(0.75rem, 2vw, 0.85rem);
   color: #888;
   margin-top: 5px;
@@ -165,6 +188,7 @@ body {
 }
 
 .text-form {
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: clamp(15px, 2.5vw, 20px);
@@ -249,17 +273,20 @@ body {
 }
 
 .thumbnail-pop-up {
+  width: min(700px, 90vw);
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: clamp(280px, 90%, 900px);
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 6px 25px rgba(0, 0, 0, 0.15);
   z-index: 1010;
   padding: clamp(15px, 2.5vw, 20px);
   animation: animatemode 0.3s ease forwards;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .popup-header {
@@ -268,37 +295,50 @@ body {
   align-items: center;
   padding-bottom: clamp(10px, 2vw, 15px);
   border-bottom: 1px solid #eee;
+  margin-bottom: 5px;
 }
 
 .popup-header h2 {
   font-size: clamp(1.25rem, 3vw, 1.5rem);
   font-weight: 600;
   color: var(--squid-ink);
+  margin: 0;
 }
 
 .discard-btn {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 8px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
-  transition: background 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
 }
 
 .discard-btn:hover {
-  background: #f0f0f0;
+  background-color: #f0f0f0;
+}
+
+.discard-btn:focus {
+  outline: 2px solid var(--neon-blue);
+  outline-offset: 2px;
 }
 
 .thumbnail-container {
   display: grid;
-  grid-template-columns: repeat(
-    auto-fill,
-    minmax(clamp(120px, 25vw, 150px), 1fr)
-  );
-  gap: clamp(10px, 2vw, 15px);
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-auto-rows: minmax(160px, 1fr);
+  grid-auto-flow: row;
+  gap: 12px;
   padding: clamp(15px, 3vw, 20px) 0;
-  max-height: 500px;
   overflow-y: auto;
+  overflow-x: hidden;
+  max-height: 360px;
+  scrollbar-width: thin;
+  scrollbar-color: #888 #f0f0f0;
 }
 
 .no-notes {
@@ -306,6 +346,7 @@ body {
   padding: clamp(30px, 5vw, 40px);
   font-size: clamp(1rem, 2.5vw, 1.1rem);
   color: #666;
+  margin: auto;
 }
 
 .thumbnail-card {
@@ -313,16 +354,20 @@ body {
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s ease;
+  transition: all 0.2s ease;
+  aspect-ratio: 3/4;
+  height: 100%;
+  display: flex;
 }
 
 .thumbnail-card:hover {
   transform: scale(1.03);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .noteImage {
   width: 100%;
-  height: clamp(100px, 20vw, 150px);
+  height: 100%;
   object-fit: cover;
 }
 
@@ -333,36 +378,68 @@ body {
   background: rgba(255, 255, 255, 0.9);
   border: none;
   border-radius: 50%;
-  padding: 5px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: all 0.2s ease;
 }
 
-.thumbnail-card:hover .delete-btn {
+.thumbnail-card:hover .delete-btn,
+.thumbnail-card:focus-within .delete-btn {
   opacity: 1;
+}
+
+.thumbnail-card .delete-btn:hover {
+  background-color: rgba(255, 220, 220, 0.9);
+  transform: scale(1.1);
 }
 
 .thumbnail-card .delete-btn:hover svg path {
   fill: #d9534f;
 }
 
+/* Improved scrollbar styling */
 .thumbnail-container::-webkit-scrollbar {
-  width: 6px;
+  width: 8px;
+  height: 8px;
 }
 
 .thumbnail-container::-webkit-scrollbar-track {
   background: #f0f0f0;
-  border-radius: 3px;
+  border-radius: 4px;
 }
 
 .thumbnail-container::-webkit-scrollbar-thumb {
   background: #888;
-  border-radius: 3px;
+  border-radius: 4px;
 }
 
 .thumbnail-container::-webkit-scrollbar-thumb:hover {
-  background: #555;
+  background: #666;
+}
+
+@media (max-width: 480px) {
+  .middle-section {
+    margin-top: 60px;
+    margin-bottom: 60px;
+  }
+  .thumbnail-container {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+  }
+  
+  .thumbnail-card {
+    aspect-ratio: 1/1;
+  }
+  
+  .discard-btn {
+    width: 32px;
+    height: 32px;
+  }
 }
 
 .overlay {
@@ -418,7 +495,6 @@ body {
   }
 }
 
-/* Media Queries */
 @media (min-width: 769px) {
   .middle-section {
     width: 600px;
@@ -431,6 +507,7 @@ body {
 
 @media (max-width: 768px) {
   .middle-section {
+    margin-bottom: 60px;
     width: 100%;
     padding: 20px;
   }
@@ -475,3 +552,4 @@ body {
     grid-template-columns: 1fr;
   }
 }
+


### PR DESCRIPTION
I added a console.log in the handlePublish function so you can see the noteData object (with the title, subject, description, and array of image files) in the console whenever someone clicks "Publish". I added a cleanup function in the useEffect hook to set quillRef.current = null when the component unmounts. This prevents memory leaks if the user navigates away and comes back. After a successful publish (simulated with the response.ok check), I made sure the entire form resets properly. Now it clears the uploaded files (stackFiles), closes the thumbnail popup, resets the file input, clears the subject and title fields, and empties the Quill editor. The form is ready for a fresh start after each publish!

Also I tried to connect. let me know if you found it... in handlepublish()