### PR TITLE
infra-dev:feat:introduced development only session.stdid handling via session.mstdid (mock student id)

### DIFF
--- a/.githooks/.commit-tags.ini
+++ b/.githooks/.commit-tags.ini
@@ -1,4 +1,4 @@
-taskids=jest,git-manage,frnd-flw,usr-clf,job-queue,pass-rst,usr-prfl,left-pnl
+taskids=jest,git-manage,frnd-flw,usr-clf,job-queue,pass-rst,usr-prfl,left-pnl,infra-dev
 tags=feat,fix,docs,style,refactor,test,impr,chore,wip,revert,fixup,hotfix,rule
 
 # tags dictionary

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -53,6 +53,18 @@ const port = process.env.PORT
 const staticPath = join(__dirname, "../../frontend/dist")
 const allowedHosts = JSON.parse(process.env.ALLOWED_HOSTS)
 
+function devAuthCookie(req, res, next) {
+    const mockSessionUserID = req.headers['x-msid'] 
+    if (mockSessionUserID) {
+        req.session.mstdid = mockSessionUserID
+    } else {
+        console.log(chalk.red("DEVELOPMENT_SESSION_COOKIE is set to true but no x-msid header is found. Setting mstdid=undefined"))
+        req.session.mstdid = undefined
+    }
+
+    next()
+}
+
 app.use(cors({
     origin: allowedHosts,
     credentials: true
@@ -74,6 +86,10 @@ app.use(session({
         maxAge: 1000 * 60 * 60 * 720
     }
 }));
+if (process.env.DEVELOPMENT_SESSION_COOKIE === "true") {
+    console.log(chalk.cyan(`[-] using development session cookie: ${chalk.yellow('`session.mstdid`')}`))
+    app.use(devAuthCookie)
+}
 app.use(cookieParser()) 
 app.use(fileUpload()) 
 


### PR DESCRIPTION
When testing APIs, sometimes we have to replicate multiple users role. For that, we had to rely on the `session.stdid` cookie which holds the studentID of the **logged-in** user as a session cookie. But it causes some problems cause one the request header can contain one session cookie. 

Now, if the `DEVELOPMENT_SESSION_COOKIE` environment variable is set to true, express will expect a header called `x-msid` (short for **mock student ID**) which will hold the user's studentID and express will set that mock student ID to `session.mstdid`. You can access that anywhere in the project using `req.session["mstdid"]` as you access `stdid`. In this way, you can open multiple postman tabs, and set different `x-msid` values and perform API testing replicating multiple users.

Request header setting in PostMan
![Screenshot (406)](https://github.com/user-attachments/assets/48cbe6b6-f463-4e05-8dbb-18d51578b796)
You have to navigate to Headers section and set that `x-msid` to desired studentID. 

> [!IMPORTANT]
> You have to set `DEVELOPMENT_SESSION_COOKIE=true` in your .env file and set a valid studentID in `x-msid` header
