### PR TITLE
usr-clf:feat:username change when displayname changes (linkedIN type) Feature-flag for separate username change acceptance

### DIFF
--- a/backend/apis/profile.api.ts
+++ b/backend/apis/profile.api.ts
@@ -3,6 +3,11 @@ import { Server } from "socket.io";
 import { Convert, getMutualCollegeStudents, getProfile, updateProfileFields } from "../services/user.service";
 import sanitizeHtml from 'sanitize-html';
 import logger from "../logger";
+import validator from "validator";
+
+const FeatureFlags = {
+	ACCEPT_USERNAME_CHANGE_VIA_API: false
+}
 
 const router = Router()
 export const ALLOWED_CHANGEABLE_FIELDS = [
@@ -12,8 +17,19 @@ export const ALLOWED_CHANGEABLE_FIELDS = [
 	"favouritesubject",
 	"notfavsubject",
 	"group",
-	"collegeyear"
+	"collegeyear",
+	...[FeatureFlags.ACCEPT_USERNAME_CHANGE_VIA_API && "username"]
 ]
+
+function isValidUsername(username: string): boolean {
+	if (username.length < 4) return false;
+
+	if (!validator.isAscii(username)) return false;
+
+	const regex = /^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?$/;
+	return regex.test(username);
+}
+
 
 export default function profileApiRouter(io: Server) {
 	router.get("/mutual-college", async (req, res) => {
@@ -60,17 +76,17 @@ export default function profileApiRouter(io: Server) {
 
 	router.post("/change", async (req, res: any) => {
 		try {
-			const studentID = req.session?.["stdid"];
-			if (!studentID) return
+			const studentID = req.session["stdid"];
+			if (!studentID) return;
 
-			// Check group from request body
 			const group = req.body.group?.trim();
-			if (!group || !["Science", "Commerce", "Arts"].includes(group)) {
-				logger.warn(`Invalid or missing group for student ${studentID}: ${group}`);
-				return res.json({ ok: false, message: "Invalid or missing group." });
-			}
+			if (group) {
+				if (!["Science", "Commerce", "Arts"].includes(group)) {
+					logger.warn(`Invalid or missing group for student ${studentID}: ${group}`);
+					return res.json({ ok: false, message: "Invalid or missing group." });
+				}
 
-			logger.info(`Student ID: ${studentID}, Group: ${group}`);
+			}
 
 			const updates: Record<string, string> = {};
 
@@ -88,6 +104,16 @@ export default function profileApiRouter(io: Server) {
 					return res.json({ ok: false, message: `Value for "${key}" cannot be empty.` });
 				}
 
+				if (FeatureFlags.ACCEPT_USERNAME_CHANGE_VIA_API && key === "username" && !isValidUsername(value)) {
+					logger.warn(`Invalid username attempt by student ${studentID}: "${value}"`);
+					return res.json({
+						ok: false,
+						message:
+							"Invalid username. Use only letters, numbers, dot (.), underscore (_) or dash (-). It must be at least 4 characters long and cannot start or end with punctuation."
+					});
+				}
+
+
 				updates[key] = value;
 			}
 
@@ -102,6 +128,9 @@ export default function profileApiRouter(io: Server) {
 				res.json({ ok: true });
 			} else {
 				logger.error(`Update failed for student ${studentID}`);
+				if (response.error.code && response.error.code === 11000) {
+					return res.json({ ok: false, message: "Username is not available" });
+				}
 				res.json({ ok: false, message: "Can't change your profile details now! Please try again a bit later" });
 			}
 		} catch (error) {

--- a/backend/services/user.service.ts
+++ b/backend/services/user.service.ts
@@ -1,5 +1,7 @@
 import Students from "../schemas/users.model"
 import mongoose from "mongoose"
+import { v4 as uuidv4 } from "uuid"
+import { generateRandomUsername } from "./utils"
 
 export const Convert = {
     async getStudentID_username(username: string) {
@@ -160,8 +162,16 @@ export async function searchStudent(searchTerm: string, options?: any) {
 }
 
 export async function updateProfileFields(studentID: string, updates: Record<string, string>) {
-    //TODO: add profile picture change logic (@rafi)
+    //TODO: add profile picture change logic
+
     try {
+        if (Object.keys(updates).includes("displayname")) {
+            const response = generateRandomUsername(updates.displayname, true)
+            const currentUsername = await Convert.getUserName_studentid(studentID)
+            const randomPortion = currentUsername.split("-").pop()
+            const username = `${response.username}-${randomPortion || uuidv4().split("-")[0]}`
+            updates.username = username
+        }
         await Students.updateOne({ studentID: studentID }, updates);
         return { ok: true }
     } catch (error) {

--- a/backend/services/utils.ts
+++ b/backend/services/utils.ts
@@ -55,21 +55,28 @@ export async function processBuikPDFUpload(fileObjects: fileUpload.UploadedFile[
 }
 
 
-export function generateRandomUsername(displayname: string) {
-    let sluggfied = slugify(displayname, {
-        lower: true,
-        strict: true
-    })
-    let uuid = uuidv4()
-    let suffix = uuid.split("-")[0]
-    let username = `${sluggfied}-${suffix}`
+type UserInfo = { userID?: string, username?: string }
+export function generateRandomUsername(displayname: string, onlyTextPortion: boolean = false): UserInfo  {
+    const uuid = uuidv4()
+    const suffix = uuid.split("-")[0]
 
-    return {
-        userID: uuid,
-        username: username
+    try {
+        let username: string = ""
+        const normalizedDisplayName = displayname.normalize("NFKD").replace(/[\u0300-\u036f]/g, "")
+        const sluggfied = slugify(normalizedDisplayName, { lower: true, strict: true })
+
+        if (sluggfied.trim().length !== 0) {
+            username = onlyTextPortion ? sluggfied : `${sluggfied}-${suffix}`
+        } else {
+            const textPortion = displayname.toLowerCase().replace(/\s+/g, "-")
+            username = onlyTextPortion ? textPortion : `${textPortion}-${suffix}`
+        }
+
+        return { userID: uuid, username: username }
+    } catch (error) {
+        return { userID: uuid, username: onlyTextPortion ? `nr-user` : `nr-user-${suffix}` }
     }
 }
-
 
 export const userMentionMap = {
     mentionRegex: /(\@[\w+\-]+)/,


### PR DESCRIPTION
Username now can be changed in 2 ways:
1. when the displayname changes. We followed linkedIN type feature where the text portion of the username which contains the sluggified displayname changes, but the random portion doesn't get changed. Error fallbacks the username to `nr-user-<random>`
2. we can change username separately, but that is disabled by default using a feature flag